### PR TITLE
verity: add API to get hash tree storage size

### DIFF
--- a/pkg/verity/merkle.go
+++ b/pkg/verity/merkle.go
@@ -127,6 +127,20 @@ func (vh *VerityHash) hashLevels(dataFileBlocks uint64) ([]hashTreeLevel, error)
 	return levels, nil
 }
 
+func (vh *VerityHash) GetHashTreeSize() (uint64, error) {
+	levels, err := vh.hashLevels(vh.dataBlocks)
+	if err != nil {
+		return 0, err
+	}
+
+	totalHashBlocks := uint64(0)
+	for _, level := range levels {
+		totalHashBlocks += level.numBlocks
+	}
+
+	return totalHashBlocks * uint64(vh.hashBlockSize), nil
+}
+
 func (vh *VerityHash) verifyHashBlock(data, salt []byte) ([]byte, error) {
 	h := vh.hashFunc.New()
 

--- a/pkg/verity/verity.go
+++ b/pkg/verity/verity.go
@@ -290,3 +290,26 @@ func DumpDevice(hashPath string) (string, error) {
 
 	return sb.String(), nil
 }
+
+func GetHashTreeSize(params *VerityParams) (uint64, error) {
+	if params == nil {
+		return 0, errors.New("verity: nil params")
+	}
+
+	if params.DataBlocks == 0 {
+		return 0, errors.New("data blocks must be greater than 0")
+	}
+
+	vh := NewVerityHash(
+		params.HashName,
+		params.DataBlockSize, params.HashBlockSize,
+		params.DataBlocks,
+		params.HashType,
+		nil,
+		0,
+		"", "",
+		nil,
+	)
+
+	return vh.GetHashTreeSize()
+}


### PR DESCRIPTION
Add GetHashTreeSize() API to calculate required storage space for dm-verity hash tree before creation, enabling pre-allocation.