### PR TITLE
dm: implement dm-verity signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ go test ./...
 - Superblock read/write operations
 - Block device size detection
 - Cross-validation with C veritysetup
+- Root hash signature verification
 
 #### Hash Algorithms
 - SHA1, SHA256 (default), SHA512
@@ -230,7 +231,6 @@ go test ./...
 - FEC (Forward Error Correction) support
 - Advanced error handling modes
 - Deferred device removal
-- Root hash signature verification
 - BLAKE2, SHA3 hash algorithms
 - Parallel hashing for performance
 

--- a/cmd/veritysetup-go/flags.go
+++ b/cmd/veritysetup-go/flags.go
@@ -19,6 +19,7 @@ type CommonFlags struct {
 	HashOffset    *uint64
 	UUIDStr       *string
 	FormatType    *uint
+	RootHashSig   *string
 }
 
 func defaultFlags(fs *flag.FlagSet) *CommonFlags {
@@ -32,6 +33,7 @@ func defaultFlags(fs *flag.FlagSet) *CommonFlags {
 		HashOffset:    fs.Uint64("hash-offset", 0, "hash area offset when no superblock"),
 		UUIDStr:       fs.String("uuid", "", "UUID (RFC4122)"),
 		FormatType:    fs.Uint("format", 1, "Format type (1 - normal, 0 - original Chrome OS)"),
+		RootHashSig:   fs.String("root-hash-signature", "", "Path to root hash signature file"),
 	}
 }
 

--- a/cmd/veritysetup-go/main.go
+++ b/cmd/veritysetup-go/main.go
@@ -35,7 +35,7 @@ func main() {
 			log.Fatalf("verify: %v", err)
 		}
 	case "open":
-		p, dataDev, name, hashDev, rootDigest, flags, err := parseOpenArgs(os.Args[2:])
+		p, dataDev, name, hashDev, rootDigest, flags, signatureFile, err := parseOpenArgs(os.Args[2:])
 		if err != nil {
 			usage()
 			log.Fatalf("open: %v", err)
@@ -44,7 +44,7 @@ func main() {
 			log.Fatalf("open: %v", err)
 		}
 
-		if err := runOpen(p, dataDev, name, hashDev, rootDigest, flags); err != nil {
+		if err := runOpen(p, dataDev, name, hashDev, rootDigest, flags, signatureFile); err != nil {
 			log.Fatalf("open: %v", err)
 		}
 	case "close":
@@ -116,4 +116,5 @@ func usage() {
 	fmt.Fprintf(os.Stderr, "  --data-blocks <n>                  Data blocks (override device size)\n")
 	fmt.Fprintf(os.Stderr, "  --no-superblock                    Hash device has no superblock\n")
 	fmt.Fprintf(os.Stderr, "  --hash-offset <bytes>              Hash area offset (when --no-superblock)\n")
+	fmt.Fprintf(os.Stderr, "  --root-hash-signature <file>       Path to root hash signature file\n")
 }

--- a/cmd/veritysetup-go/open.go
+++ b/cmd/veritysetup-go/open.go
@@ -4,28 +4,32 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"time"
 
+	"golang.org/x/sys/unix"
+
 	dm "github.com/ChengyuZhu6/veritysetup-go/pkg/dm"
+	"github.com/ChengyuZhu6/veritysetup-go/pkg/keyring"
 	"github.com/ChengyuZhu6/veritysetup-go/pkg/utils"
 	verity "github.com/ChengyuZhu6/veritysetup-go/pkg/verity"
 )
 
-func parseOpenArgs(args []string) (*verity.VerityParams, string, string, string, []byte, []string, error) {
+func parseOpenArgs(args []string) (*verity.VerityParams, string, string, string, []byte, []string, string, error) {
 	fs := flag.NewFlagSet("open", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 
 	flags := defaultFlags(fs)
 
 	if err := fs.Parse(args); err != nil {
-		return nil, "", "", "", nil, nil, err
+		return nil, "", "", "", nil, nil, "", err
 	}
 
 	rest := fs.Args()
 	if len(rest) < 4 {
-		return nil, "", "", "", nil, nil, errors.New("require <data_device> <name> <hash_device> <root_hash>")
+		return nil, "", "", "", nil, nil, "", errors.New("require <data_device> <name> <hash_device> <root_hash>")
 	}
 	dataDev := rest[0]
 	name := rest[1]
@@ -33,13 +37,13 @@ func parseOpenArgs(args []string) (*verity.VerityParams, string, string, string,
 	rootHex := rest[3]
 
 	if strings.TrimSpace(name) == "" {
-		return nil, "", "", "", nil, nil, fmt.Errorf("device name is required")
+		return nil, "", "", "", nil, nil, "", fmt.Errorf("device name is required")
 	}
 	if strings.Contains(name, "/") {
-		return nil, "", "", "", nil, nil, fmt.Errorf("device name must not contain '/' characters")
+		return nil, "", "", "", nil, nil, "", fmt.Errorf("device name must not contain '/' characters")
 	}
 	if len(name) >= dm.DMNameLen {
-		return nil, "", "", "", nil, nil, fmt.Errorf("device name too long (max %d characters)", dm.DMNameLen-1)
+		return nil, "", "", "", nil, nil, "", fmt.Errorf("device name too long (max %d characters)", dm.DMNameLen-1)
 	}
 
 	p := verity.DefaultVerityParams()
@@ -53,16 +57,16 @@ func parseOpenArgs(args []string) (*verity.VerityParams, string, string, string,
 	}
 
 	if err := validateAndApplyBlockSizes(&p, flags); err != nil {
-		return nil, "", "", "", nil, nil, err
+		return nil, "", "", "", nil, nil, "", err
 	}
 
 	if err := utils.ValidateHashOffset(p.HashAreaOffset, p.HashBlockSize, p.NoSuperblock); err != nil {
-		return nil, "", "", "", nil, nil, err
+		return nil, "", "", "", nil, nil, "", err
 	}
 
 	salt, saltSize, err := utils.ApplySalt(*flags.SaltHex, int(verity.MaxSaltSize))
 	if err != nil {
-		return nil, "", "", "", nil, nil, err
+		return nil, "", "", "", nil, nil, "", err
 	}
 	p.Salt = salt
 	p.SaltSize = saltSize
@@ -70,21 +74,35 @@ func parseOpenArgs(args []string) (*verity.VerityParams, string, string, string,
 	if *flags.NoSuper {
 		dataBlocks, err := utils.CalculateDataBlocks(dataDev, *flags.DataBlocks, p.DataBlockSize)
 		if err != nil {
-			return nil, "", "", "", nil, nil, err
+			return nil, "", "", "", nil, nil, "", err
 		}
 		p.DataBlocks = dataBlocks
 	}
 
 	rootBytes, err := utils.ParseRootHash(rootHex)
 	if err != nil {
-		return nil, "", "", "", nil, nil, err
+		return nil, "", "", "", nil, nil, "", err
 	}
 
 	var dmFlags []string
-	return &p, dataDev, name, hashDev, rootBytes, dmFlags, nil
+	signatureFile := *flags.RootHashSig
+	return &p, dataDev, name, hashDev, rootBytes, dmFlags, signatureFile, nil
 }
 
-func runOpen(p *verity.VerityParams, dataDev, name, hashDev string, rootDigest []byte, flags []string) error {
+func runOpen(p *verity.VerityParams, dataDev, name, hashDev string, rootDigest []byte, flags []string, signatureFile string) error {
+	var keyID keyring.KeySerial
+	var keyDesc string
+
+	if signatureFile != "" {
+		if err := keyring.CheckKeyringSupport(); err != nil {
+			return fmt.Errorf("signature verification requires kernel keyring support: %w", err)
+		}
+
+		if err := dm.CheckVeritySignatureSupport(); err != nil {
+			return fmt.Errorf("failed to check dm-verity signature support: %w", err)
+		}
+	}
+
 	dataLoop, cleanup, err := utils.SetupLoopDevice(dataDev)
 	if err != nil {
 		return fmt.Errorf("setup data loop device: %w", err)
@@ -113,18 +131,52 @@ func runOpen(p *verity.VerityParams, dataDev, name, hashDev string, rootDigest [
 		return err
 	}
 
+	if signatureFile != "" {
+		signatureData, err := os.ReadFile(signatureFile)
+		if err != nil {
+			return fmt.Errorf("failed to read signature file: %w", err)
+		}
+
+		uuidStr := ""
+		if p.UUID != ([16]byte{}) {
+			uuidStr = fmt.Sprintf("%x-%x-%x-%x-%x",
+				p.UUID[0:4], p.UUID[4:6], p.UUID[6:8],
+				p.UUID[8:10], p.UUID[10:16])
+		}
+
+		if uuidStr != "" {
+			keyDesc = fmt.Sprintf("cryptsetup:%s-%s", uuidStr, name)
+		} else {
+			keyDesc = fmt.Sprintf("cryptsetup:%s", name)
+		}
+
+		keyID, err = keyring.AddKeyToThreadKeyring("user", keyDesc, signatureData)
+		if err != nil {
+			return fmt.Errorf("failed to load signature into keyring: %w", err)
+		}
+
+		log.Printf("Loaded signature into thread keyring (key ID: %d, description: %s)\n", keyID, keyDesc)
+
+		defer func() {
+			if err := keyring.UnlinkKeyFromThreadKeyring(keyID); err != nil {
+				log.Printf("Warning: failed to unlink key from keyring: %v", err)
+			}
+		}()
+	}
+
 	a := dm.OpenArgs{
-		Version:        p.HashType,
-		DataDevice:     dataLoop,
-		HashDevice:     hashLoop,
-		DataBlockSize:  p.DataBlockSize,
-		HashBlockSize:  p.HashBlockSize,
-		DataBlocks:     p.DataBlocks,
-		HashName:       p.HashName,
-		RootDigest:     rootDigest,
-		Salt:           p.Salt,
-		HashStartBytes: p.HashAreaOffset,
-		Flags:          flags,
+		Version:            p.HashType,
+		DataDevice:         dataLoop,
+		HashDevice:         hashLoop,
+		DataBlockSize:      p.DataBlockSize,
+		HashBlockSize:      p.HashBlockSize,
+		DataBlocks:         p.DataBlocks,
+		HashName:           p.HashName,
+		RootDigest:         rootDigest,
+		Salt:               p.Salt,
+		HashStartBytes:     p.HashAreaOffset,
+		Flags:              flags,
+		RootHashSigKeyDesc: keyDesc,
 	}
 	params, err := dm.BuildTargetParams(a)
 	if err != nil {
@@ -157,6 +209,9 @@ func runOpen(p *verity.VerityParams, dataDev, name, hashDev string, rootDigest [
 	}
 	if err := c.SuspendDevice(name, false); err != nil {
 		_ = c.RemoveDevice(name)
+		if signatureFile != "" && errors.Is(err, unix.EKEYREJECTED) {
+			return fmt.Errorf("signature verification failed: key rejected by kernel")
+		}
 		return fmt.Errorf("resume device: %w", err)
 	}
 	created = true

--- a/cmd/veritysetup-go/open_linux_test.go
+++ b/cmd/veritysetup-go/open_linux_test.go
@@ -204,7 +204,7 @@ func TestParseOpenArgs_InvalidArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, _, _, _, _, err := parseOpenArgs(tt.args)
+			_, _, _, _, _, _, _, err := parseOpenArgs(tt.args)
 			if err == nil {
 				t.Error("expected error, got nil")
 			}

--- a/pkg/dm/target.go
+++ b/pkg/dm/target.go
@@ -7,17 +7,18 @@ import (
 )
 
 type OpenArgs struct {
-	Version        uint32 // verity target version, usually 1
-	DataDevice     string // path to data device
-	HashDevice     string // path to hash device
-	DataBlockSize  uint32 // bytes
-	HashBlockSize  uint32 // bytes
-	DataBlocks     uint64 // number of data blocks
-	HashName       string // sha256, sha1, sha512
-	RootDigest     []byte // root hash digest (binary)
-	Salt           []byte // salt (binary)
-	HashStartBytes uint64 // byte offset of hash area start on hash device
-	Flags          []string
+	Version            uint32
+	DataDevice         string
+	HashDevice         string
+	DataBlockSize      uint32
+	HashBlockSize      uint32
+	DataBlocks         uint64
+	HashName           string
+	RootDigest         []byte
+	Salt               []byte
+	HashStartBytes     uint64
+	Flags              []string
+	RootHashSigKeyDesc string
 }
 
 func BuildTargetParams(a OpenArgs) (string, error) {
@@ -63,8 +64,22 @@ func BuildTargetParams(a OpenArgs) (string, error) {
 		saltHex,
 	)
 
-	if len(a.Flags) > 0 {
-		b += " " + strings.Join(a.Flags, " ")
+	optionalCount := len(a.Flags)
+	if a.RootHashSigKeyDesc != "" {
+		optionalCount += 2
 	}
+
+	if optionalCount > 0 {
+		b += fmt.Sprintf(" %d", optionalCount)
+
+		for _, flag := range a.Flags {
+			b += " " + flag
+		}
+
+		if a.RootHashSigKeyDesc != "" {
+			b += fmt.Sprintf(" root_hash_sig_key_desc %s", a.RootHashSigKeyDesc)
+		}
+	}
+
 	return b, nil
 }

--- a/pkg/keyring/keyring_linux.go
+++ b/pkg/keyring/keyring_linux.go
@@ -1,0 +1,35 @@
+package keyring
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+type KeySerial int32
+
+func CheckKeyringSupport() error {
+	_, err := unix.KeyctlSearch(unix.KEY_SPEC_THREAD_KEYRING, "logon", "dummy", 0)
+	if err == unix.ENOSYS {
+		return fmt.Errorf("kernel keyring not supported")
+	}
+	return nil
+}
+
+func AddKeyToThreadKeyring(keyType, description string, payload []byte) (KeySerial, error) {
+	keyID, err := unix.AddKey(keyType, description, payload, unix.KEY_SPEC_THREAD_KEYRING)
+	if err != nil {
+		return 0, fmt.Errorf("add_key syscall failed: %w", err)
+	}
+
+	return KeySerial(keyID), nil
+}
+
+func UnlinkKeyFromThreadKeyring(keyID KeySerial) error {
+	_, err := unix.KeyctlInt(unix.KEYCTL_UNLINK, int(keyID), unix.KEY_SPEC_THREAD_KEYRING, 0, 0)
+	if err != nil {
+		return fmt.Errorf("keyctl unlink failed: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/keyring/keyring_linux_test.go
+++ b/pkg/keyring/keyring_linux_test.go
@@ -1,0 +1,26 @@
+package keyring
+
+import (
+	"testing"
+)
+
+func TestAddAndUnlinkKey(t *testing.T) {
+	if err := CheckKeyringSupport(); err != nil {
+		t.Skipf("Keyring not supported: %v", err)
+	}
+
+	payload := []byte("test-payload")
+	keyID, err := AddKeyToThreadKeyring("user", "test-key", payload)
+	if err != nil {
+		t.Fatalf("Failed to add key: %v", err)
+	}
+
+	if keyID == 0 {
+		t.Fatal("Expected non-zero key ID")
+	}
+
+	err = UnlinkKeyFromThreadKeyring(keyID)
+	if err != nil {
+		t.Fatalf("Failed to unlink key: %v", err)
+	}
+}


### PR DESCRIPTION
Add signature support for dm-verity root hash verification:
- Add --root-hash-signature flag
- Implement kernel keyring integration
- Add signature verification tests